### PR TITLE
be quiet by default

### DIFF
--- a/ratiocinate.js
+++ b/ratiocinate.js
@@ -31,7 +31,10 @@
   if (!url.match(/:\/\//)) {
     if (!fs.exists(url)) {
       url = 'http://' + url;
-      verbose && console.log('Missing protocol, assuming http');
+
+      if (verbose) {
+        console.log('Missing protocol, assuming http');
+      }
     } else if(verbose) {
       console.log('"' + url + '" exists locally, using that.');
       console.log('Prepend a protocol (e.g. http:// or https://) to override this behavior');
@@ -45,8 +48,8 @@
   };
 
   page.open(url, function (status) {
-    if (status !== 'success') {
-      verbose && console.log('Failed to load "' + url + '"');
+    if (status !== 'success' && verbose) {
+      console.log('Failed to load "' + url + '"');
     } else {
       page.injectJs("vendor/jquery-1.8.2.js");
       page.injectJs("vendor/underscore-1.4.2.js");


### PR DESCRIPTION
don't output debugging information by default, that way the output of
this tool can be piped around without stripping out extra information
first.

to do this I had to add the ability to process arguments.  to do THAT I
added underscore to ratiocinate.js, so the 'require' line will need to
be upgraded when underscore is updated/moved.  There might be a more
desirable way to do this.

as a final note, the verbose option is brittle because `verbose` needs
to be considered when logging information out (are we logging output or
messages?).  I was going to fix this by unifying logging under a
'lib/log.js' file, or by overriding `console.log`, but this change
seemed to be the smallest, so I opted for it instead :)
