### PR TITLE
switch to jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "browser": true,
+  "indent": 2,
+  "undef": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - 0.10
-before_install: "npm install -g nodelint"
+before_install: "npm install -g jshint"
 script:
-  - nodelint ./*.js lib/*.js extras/*.js
+  - jshint ./*.js lib/*.js extras/*.js
   - phantomjs test.js

--- a/extras/bookmarklet.js
+++ b/extras/bookmarklet.js
@@ -1,5 +1,4 @@
-/*jslint browser: true, indent: 2, nomen: true */
-/*global _, jQuery, $, console, CSS */
+/* global _, jQuery, $, console, CSS */
 
 (function () {
   "use strict";

--- a/lib/async.js
+++ b/lib/async.js
@@ -1,5 +1,4 @@
-/*jslint browser: true, indent: 2, nomen: true */
-/*global _, require, exports */
+/* global _, require, exports */
 
 (function () {
   "use strict";

--- a/lib/css.js
+++ b/lib/css.js
@@ -1,5 +1,4 @@
-/*jslint browser: true, indent: 2, nomen: true */
-/*global exports, _, jQuery, OBJ, console, CSSFontFaceRule */
+/* global exports, _, jQuery, OBJ, console, CSSFontFaceRule */
 
 var CSS = (function () {
   "use strict";
@@ -52,7 +51,8 @@ var CSS = (function () {
       'caption-side', 'direction', 'elevation', 'empty-cells', 'line-height', 'list-style-image',
       'list-style-position', 'list-style-type', 'list-style', 'orphans', 'pitch-range',
       'pitch', 'quotes', 'richness', 'speak-header', 'speak-numeral', 'speak-punctuation',
-      'speak', 'speech-rate', 'stress', 'visibility', 'voice-family', 'volume', 'widows'];
+      'speak', 'speech-rate', 'stress', 'visibility', 'voice-family', 'volume', 'widows'
+    ];
 
     node.children().each(function (i, kid) {
       var common = _.pick(commonStyle([node, $(kid)]), heritable);

--- a/lib/obj.js
+++ b/lib/obj.js
@@ -1,5 +1,4 @@
-/*jslint indent: 2, nomen: true */
-/*global _, exports */
+/* global _, exports */
 
 var OBJ = (function () {
   "use strict";

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,5 +1,4 @@
-/*jslint browser: true, indent: 2 */
-/*global phantom, exports, require, console */
+/* global phantom, exports, require, console */
 
 (function () {
   "use strict";

--- a/originalcss.js
+++ b/originalcss.js
@@ -1,5 +1,4 @@
-/*jslint browser: true, indent: 2, nomen: true */
-/*global phantom, require, console, _, jQuery, CSSImportRule */
+/* global phantom, require, console, _, jQuery, CSSImportRule */
 (function () {
   "use strict";
 

--- a/ratiocinate.js
+++ b/ratiocinate.js
@@ -1,5 +1,4 @@
-/*jslint browser: true, indent: 2, nomen: true */
-/*global phantom, CSS, require, console, $, simplerStyle, _ */
+/* global phantom, CSS, require, console, $, simplerStyle, _ */
 
 (function () {
   "use strict";

--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
-/*jslint browser: true, indent: 2, nomen: true */
-/*global phantom, require, console, $, _, CSS, jasmine, describe, it, expect */
+/* global phantom, require, console, $, _, CSS, jasmine, describe, it, expect */
 (function () {
   "use strict";
 


### PR DESCRIPTION
reasons:
- jshint has more options
- jshint's options are well documented, with examples
  - see: http://www.jshint.com/docs/#options
- jshint differentiates between warnings and errors (not sure if jshint
  doesn't do this, or I'm just not sure how to set it.  looking at
  http://www.jslint.com/lint.html I'm thinking jslint doesn't support
  warnings vs errors)
  - NOTE: for vim you can get https://github.com/scrooloose/syntastic
    which will show you both for linted files
- jshint supports a directory-specific `.jshintrc` options, in addition
  to a `.jshintignore` file
  - this could save some typing, though we would probably still need to
    leave the `/* global */` comments in there as they appear to be
    file-specific
  - more info no the options page: http://www.jshint.com/docs/#options

NOTE: The 'jslint' comments at the top are now moved into a
project-specific '.jshintrc' json file.  The global comments can still
be used to identify external variables in each script, with the only
difference being `browser: true` in '.jshintrc' may be a little
different than `browser: true` in the jslint comments (they both define
a list of globals specific to the browser iiuc), but this wasn't an
issue for any of the files I've updated (those with 'jslint' comments).

NOTE: I've checked the changed files, and they all (with a small change
to the indentation in `lib/css.js`) pass without warnings or errors.

As a final note, I've changed '.travis.yml' so it should still test
the javascript files for compliance w/jshint
